### PR TITLE
prevent division by zero panics

### DIFF
--- a/src/bench.rs
+++ b/src/bench.rs
@@ -114,6 +114,12 @@ async fn run(settings: BenchmarkSettings) -> Result<()> {
         return Ok(());
     }
 
+    // prevent div-by-zero panics
+    if combiner.total_requests() == 0 {
+        println!("No requests completed successfully");
+        return Ok(());
+    }
+
     combiner.display_latencies();
     combiner.display_requests();
     combiner.display_transfer();

--- a/src/results.rs
+++ b/src/results.rs
@@ -284,7 +284,28 @@ impl WorkerResult {
     }
 
     pub fn display_json(&self) {
-        let modified = 1000 as f64;
+        // prevent div-by-zero panics
+        if self.total_requests() == 0 {
+            let null = None::<()>;
+
+            let out = json!({
+                "latency_avg": null,
+                "latency_max": null,
+                "latency_min": null,
+                "latency_std_deviation": null,
+
+                "transfer_total": null,
+                "transfer_rate": null,
+
+                "requests_total": 0,
+                "requests_avg": null,
+            });
+
+            println!("{}", out.to_string());
+            return;
+        }
+
+        let modified = 1000_f64;
         let avg = self.avg_request_latency().as_secs_f64() * modified;
         let max = self.max_request_latency().as_secs_f64() * modified;
         let min = self.min_request_latency().as_secs_f64() * modified;
@@ -293,8 +314,8 @@ impl WorkerResult {
         let total = self.total_transfer() as f64;
         let rate = self.avg_transfer();
 
-        let total_transfer = self.total_requests();
-        let avg_transfer = self.avg_request_per_sec();
+        let total_requests = self.total_requests();
+        let avg_request_per_sec = self.avg_request_per_sec();
 
         let out = json!({
             "latency_avg": avg,
@@ -305,8 +326,8 @@ impl WorkerResult {
             "transfer_total": total,
             "transfer_rate": rate,
 
-            "requests_total": total_transfer,
-            "requests_avg": avg_transfer,
+            "requests_total": total_requests,
+            "requests_avg": avg_request_per_sec,
         });
 
         println!("{}", out.to_string())


### PR DESCRIPTION
When 0 requests are processed successfully, various functions would panic when trying to calculate request averages. This avoids calling those functions by bailing early.