### PR TITLE
Support setting request method, headers, and body

### DIFF
--- a/src/bench.rs
+++ b/src/bench.rs
@@ -1,10 +1,10 @@
 use std::fmt::Display;
 use std::time::Duration;
 
+use ::http::{HeaderMap, Method};
 use anyhow::{anyhow, Result};
 use colored::*;
 use futures_util::StreamExt;
-use ::http::{HeaderMap, Method};
 use hyper::body::Bytes;
 
 use crate::results::WorkerResult;

--- a/src/bench.rs
+++ b/src/bench.rs
@@ -4,7 +4,7 @@ use std::time::Duration;
 use anyhow::{anyhow, Result};
 use colored::*;
 use futures_util::StreamExt;
-use ::http::HeaderMap;
+use ::http::{HeaderMap, Method};
 use hyper::body::Bytes;
 
 use crate::results::WorkerResult;
@@ -38,6 +38,9 @@ pub struct BenchmarkSettings {
 
     /// The number of rounds to repeat.
     pub rounds: usize,
+
+    /// The request method.
+    pub method: Method,
 
     /// Additional request headers.
     pub headers: HeaderMap,
@@ -87,6 +90,7 @@ async fn run(settings: BenchmarkSettings) -> Result<()> {
         settings.connections,
         settings.host.trim().to_string(),
         settings.bench_type,
+        settings.method,
         settings.headers,
         settings.body,
         predict_size as usize,

--- a/src/bench.rs
+++ b/src/bench.rs
@@ -5,6 +5,7 @@ use anyhow::{anyhow, Result};
 use colored::*;
 use futures_util::StreamExt;
 use ::http::HeaderMap;
+use hyper::body::Bytes;
 
 use crate::results::WorkerResult;
 use crate::utils::div_mod;
@@ -40,6 +41,9 @@ pub struct BenchmarkSettings {
 
     /// Additional request headers.
     pub headers: HeaderMap,
+
+    /// Request body.
+    pub body: Bytes,
 }
 
 /// Builds the runtime with the given settings and blocks on the main future.
@@ -84,6 +88,7 @@ async fn run(settings: BenchmarkSettings) -> Result<()> {
         settings.host.trim().to_string(),
         settings.bench_type,
         settings.headers,
+        settings.body,
         predict_size as usize,
     )
     .await;

--- a/src/bench.rs
+++ b/src/bench.rs
@@ -4,6 +4,7 @@ use std::time::Duration;
 use anyhow::{anyhow, Result};
 use colored::*;
 use futures_util::StreamExt;
+use ::http::HeaderMap;
 
 use crate::results::WorkerResult;
 use crate::utils::div_mod;
@@ -36,6 +37,9 @@ pub struct BenchmarkSettings {
 
     /// The number of rounds to repeat.
     pub rounds: usize,
+
+    /// Additional request headers.
+    pub headers: HeaderMap,
 }
 
 /// Builds the runtime with the given settings and blocks on the main future.
@@ -79,6 +83,7 @@ async fn run(settings: BenchmarkSettings) -> Result<()> {
         settings.connections,
         settings.host.trim().to_string(),
         settings.bench_type,
+        settings.headers,
         predict_size as usize,
     )
     .await;

--- a/src/http/mod.rs
+++ b/src/http/mod.rs
@@ -6,7 +6,7 @@ use anyhow::anyhow;
 use futures_util::stream::FuturesUnordered;
 use futures_util::TryFutureExt;
 use http::header::{self, HeaderMap};
-use http::{Request, Method};
+use http::{Method, Request};
 use hyper::body::Bytes;
 use hyper::client::conn::{self, SendRequest};
 use hyper::Body;
@@ -58,7 +58,8 @@ pub async fn start_tasks(
     _predicted_size: usize,
 ) -> anyhow::Result<FuturesUnordered<Handle>> {
     let deadline = Instant::now() + time_for;
-    let user_input = UserInput::new(bench_type, uri_string, method, headers, body).await?;
+    let user_input =
+        UserInput::new(bench_type, uri_string, method, headers, body).await?;
 
     let handles = FuturesUnordered::new();
 

--- a/src/http/mod.rs
+++ b/src/http/mod.rs
@@ -51,10 +51,11 @@ pub async fn start_tasks(
     connections: usize,
     uri_string: String,
     bench_type: BenchType,
+    headers: HeaderMap,
     _predicted_size: usize,
 ) -> anyhow::Result<FuturesUnordered<Handle>> {
     let deadline = Instant::now() + time_for;
-    let user_input = UserInput::new(bench_type, uri_string).await?;
+    let user_input = UserInput::new(bench_type, uri_string, headers).await?;
 
     let handles = FuturesUnordered::new();
 
@@ -94,6 +95,8 @@ async fn benchmark(
     if bench_type.is_http1() {
         request_headers.insert(header::HOST, user_input.host_header);
     }
+
+    request_headers.extend(user_input.headers);
 
     let mut request_times = Vec::new();
     let mut error_map = HashMap::new();

--- a/src/http/user_input.rs
+++ b/src/http/user_input.rs
@@ -2,7 +2,7 @@ use std::convert::TryFrom;
 use std::net::{SocketAddr, ToSocketAddrs};
 
 use anyhow::{anyhow, Result};
-use http::HeaderMap;
+use http::{HeaderMap, Method};
 use http::header::HeaderValue;
 use http::uri::Uri;
 use hyper::body::Bytes;
@@ -33,18 +33,19 @@ pub(crate) struct UserInput {
     pub(crate) host: String,
     pub(crate) host_header: HeaderValue,
     pub(crate) uri: Uri,
+    pub(crate) method: Method,
     pub(crate) headers: HeaderMap,
     pub(crate) body: Bytes,
 }
 
 impl UserInput {
-    pub(crate) async fn new(protocol: BenchType, string: String, headers: HeaderMap, body: Bytes) -> Result<Self> {
-        spawn_blocking(move || Self::blocking_new(protocol, string, headers, body))
+    pub(crate) async fn new(protocol: BenchType, string: String, method: Method, headers: HeaderMap, body: Bytes) -> Result<Self> {
+        spawn_blocking(move || Self::blocking_new(protocol, string, method, headers, body))
             .await
             .unwrap()
     }
 
-    fn blocking_new(protocol: BenchType, string: String, headers: HeaderMap, body: Bytes) -> Result<Self> {
+    fn blocking_new(protocol: BenchType, string: String, method: Method, headers: HeaderMap, body: Bytes) -> Result<Self> {
         let uri = Uri::try_from(string)?;
         let scheme = uri
             .scheme()
@@ -95,6 +96,7 @@ impl UserInput {
             host,
             host_header,
             uri,
+            method,
             headers,
             body,
         })

--- a/src/http/user_input.rs
+++ b/src/http/user_input.rs
@@ -5,6 +5,7 @@ use anyhow::{anyhow, Result};
 use http::HeaderMap;
 use http::header::HeaderValue;
 use http::uri::Uri;
+use hyper::body::Bytes;
 use tokio::task::spawn_blocking;
 use tokio_native_tls::TlsConnector;
 
@@ -33,16 +34,17 @@ pub(crate) struct UserInput {
     pub(crate) host_header: HeaderValue,
     pub(crate) uri: Uri,
     pub(crate) headers: HeaderMap,
+    pub(crate) body: Bytes,
 }
 
 impl UserInput {
-    pub(crate) async fn new(protocol: BenchType, string: String, headers: HeaderMap) -> Result<Self> {
-        spawn_blocking(move || Self::blocking_new(protocol, string, headers))
+    pub(crate) async fn new(protocol: BenchType, string: String, headers: HeaderMap, body: Bytes) -> Result<Self> {
+        spawn_blocking(move || Self::blocking_new(protocol, string, headers, body))
             .await
             .unwrap()
     }
 
-    fn blocking_new(protocol: BenchType, string: String, headers: HeaderMap) -> Result<Self> {
+    fn blocking_new(protocol: BenchType, string: String, headers: HeaderMap, body: Bytes) -> Result<Self> {
         let uri = Uri::try_from(string)?;
         let scheme = uri
             .scheme()
@@ -94,6 +96,7 @@ impl UserInput {
             host_header,
             uri,
             headers,
+            body,
         })
     }
 }

--- a/src/http/user_input.rs
+++ b/src/http/user_input.rs
@@ -2,6 +2,7 @@ use std::convert::TryFrom;
 use std::net::{SocketAddr, ToSocketAddrs};
 
 use anyhow::{anyhow, Result};
+use http::HeaderMap;
 use http::header::HeaderValue;
 use http::uri::Uri;
 use tokio::task::spawn_blocking;
@@ -31,16 +32,17 @@ pub(crate) struct UserInput {
     pub(crate) host: String,
     pub(crate) host_header: HeaderValue,
     pub(crate) uri: Uri,
+    pub(crate) headers: HeaderMap,
 }
 
 impl UserInput {
-    pub(crate) async fn new(protocol: BenchType, string: String) -> Result<Self> {
-        spawn_blocking(move || Self::blocking_new(protocol, string))
+    pub(crate) async fn new(protocol: BenchType, string: String, headers: HeaderMap) -> Result<Self> {
+        spawn_blocking(move || Self::blocking_new(protocol, string, headers))
             .await
             .unwrap()
     }
 
-    fn blocking_new(protocol: BenchType, string: String) -> Result<Self> {
+    fn blocking_new(protocol: BenchType, string: String, headers: HeaderMap) -> Result<Self> {
         let uri = Uri::try_from(string)?;
         let scheme = uri
             .scheme()
@@ -91,6 +93,7 @@ impl UserInput {
             host,
             host_header,
             uri,
+            headers,
         })
     }
 }

--- a/src/http/user_input.rs
+++ b/src/http/user_input.rs
@@ -2,9 +2,9 @@ use std::convert::TryFrom;
 use std::net::{SocketAddr, ToSocketAddrs};
 
 use anyhow::{anyhow, Result};
-use http::{HeaderMap, Method};
 use http::header::HeaderValue;
 use http::uri::Uri;
+use http::{HeaderMap, Method};
 use hyper::body::Bytes;
 use tokio::task::spawn_blocking;
 use tokio_native_tls::TlsConnector;
@@ -39,13 +39,27 @@ pub(crate) struct UserInput {
 }
 
 impl UserInput {
-    pub(crate) async fn new(protocol: BenchType, string: String, method: Method, headers: HeaderMap, body: Bytes) -> Result<Self> {
-        spawn_blocking(move || Self::blocking_new(protocol, string, method, headers, body))
-            .await
-            .unwrap()
+    pub(crate) async fn new(
+        protocol: BenchType,
+        string: String,
+        method: Method,
+        headers: HeaderMap,
+        body: Bytes,
+    ) -> Result<Self> {
+        spawn_blocking(move || {
+            Self::blocking_new(protocol, string, method, headers, body)
+        })
+        .await
+        .unwrap()
     }
 
-    fn blocking_new(protocol: BenchType, string: String, method: Method, headers: HeaderMap, body: Bytes) -> Result<Self> {
+    fn blocking_new(
+        protocol: BenchType,
+        string: String,
+        method: Method,
+        headers: HeaderMap,
+        body: Bytes,
+    ) -> Result<Self> {
         let uri = Uri::try_from(string)?;
         let scheme = uri
             .scheme()

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,11 +1,13 @@
 extern crate clap;
 
+use std::str::FromStr;
+
+use ::http::header::HeaderName;
+use ::http::{HeaderMap, HeaderValue, Method};
 use anyhow::{Context, Error, Result};
 use clap::{App, Arg, ArgMatches};
-use ::http::{header::HeaderName, HeaderMap, HeaderValue, Method};
 use hyper::body::Bytes;
 use regex::Regex;
-use std::str::FromStr;
 use tokio::time::Duration;
 
 mod bench;

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,6 +3,7 @@ extern crate clap;
 use anyhow::{Error, Result, Context};
 use clap::{App, Arg, ArgMatches};
 use ::http::{HeaderMap, header::HeaderName, HeaderValue};
+use hyper::body::Bytes;
 use regex::Regex;
 use tokio::time::Duration;
 use std::str::FromStr;
@@ -91,6 +92,11 @@ fn main() {
         HeaderMap::new()
     };
 
+    let body: &str = args
+        .value_of("body")
+        .unwrap_or_default();
+    let body = Bytes::copy_from_slice(body.as_bytes());
+
     let settings = bench::BenchmarkSettings {
         threads,
         connections: conns,
@@ -101,6 +107,7 @@ fn main() {
         display_json: json,
         rounds,
         headers,
+        body,
     };
 
     bench::start_benchmark(settings);
@@ -234,6 +241,14 @@ fn parse_args() -> ArgMatches<'static> {
                 .takes_value(true)
                 .required(false)
                 .multiple(true),
+        )
+        .arg(
+            Arg::with_name("body")
+                .long("body")
+                .short("b")
+                .help("Add body to request e.g. '-b \"foo\"'")
+                .takes_value(true)
+                .required(false),
         )
         //.arg(
         //    Arg::with_name("random")


### PR DESCRIPTION
I've been benchmarking axum's JSON handling today using rewrk with great success! But I'm having issues testing JSON input since you cannot set method, headers, and body, so figured I'd try and add it.

Example usage:

```
rewrk -d 10s -h http://localhost:3000 -m post -H "content-type: application/json" -b "{\"msg\":\"foobar\"}"
```

Just let me know if you want me to split things up into separate PRs.