### PR TITLE
Send origin-form URL in HTTP request line.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 /rewrk.exe
 /venv37
 /Cargo.lock
+/.idea

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rewrk"
-version = "0.3.2"
+version = "0.3.3"
 authors = ["Harrison Burt <57491488+ChillFish8@users.noreply.github.com>", "Programatik <programatik29@gmail.com>"]
 edition = "2018"
 

--- a/src/http/user_input.rs
+++ b/src/http/user_input.rs
@@ -92,6 +92,9 @@ impl UserInput {
             .port_u16()
             .unwrap_or_else(|| scheme.default_port());
         let host_header = HeaderValue::from_str(&host)?;
+        let path_and_query_uri = Uri::builder()
+            .path_and_query(uri.path_and_query().map(|p| p.as_str()).unwrap_or("/"))
+            .build()?;
 
         // Prefer ipv4.
         let addr_iter = (host.as_str(), port).to_socket_addrs()?;
@@ -109,7 +112,7 @@ impl UserInput {
             scheme,
             host,
             host_header,
-            uri,
+            uri: path_and_query_uri,
             method,
             headers,
             body,

--- a/src/main.rs
+++ b/src/main.rs
@@ -184,7 +184,7 @@ fn parse_header(value: &str) -> Result<(HeaderName, HeaderValue)> {
 /// Contains Clap's app setup.
 fn parse_args() -> ArgMatches<'static> {
     App::new("ReWrk")
-        .version("0.3.1")
+        .version("0.3.3")
         .author("Harrison Burt <hburt2003@gmail.com>")
         .about("Benchmark HTTP/1 and HTTP/2 frameworks without pipelining bias.")
         .arg(


### PR DESCRIPTION
This PR is a fix for https://github.com/lnx-search/rewrk/issues/47 .

RFC 7230 says that ordinary HTTP requests must use the `/path?query` part of the URL, excluding the `http://host` part:
> [5.3.1](https://datatracker.ietf.org/doc/html/rfc7230#section-5.3.1).  origin-form
> 
> The most common form of request-target is the origin-form.
> 
>     origin-form    = absolute-path [ "?" query ]
> 
> When making a request directly to an origin server, other than a
> CONNECT or server-wide OPTIONS request (as detailed below), a client
> MUST send only the absolute path and query components of the target
> URI as the request-target.  If the target URI's path component is
> empty, the client MUST send "/" as the path within the origin-form of
> request-target.  A Host header field is also sent, as defined in
> [Section 5.4](https://datatracker.ietf.org/doc/html/rfc7230#section-5.4).
> 
> For example, a client wishing to retrieve a representation of the
> resource identified as
> 
>      http://www.example.org/where?q=now
> 
> directly from the origin server would open (or reuse) a TCP
> connection to port 80 of the host "www.example.org" and send the
> lines:
> 
>     GET /where?q=now HTTP/1.1
>     Host: www.example.org
> 
> followed by the remainder of the request message.

It looks like we're sending the absolute-form url `http://127.0.0.1:3000/` when we want to send the origin-form url `/`.
We're also omitting the port number in the Location header.

Send the request:
```
% rewrk -c 1 -d 1s -h http://127.0.0.1:3000/
Beginning round 1...
Benchmarking 1 connections @ http://127.0.0.1:3000/ for 1 second(s)
No requests completed successfully

%
```

Capture the request:
```
% nc -l 3000
GET http://127.0.0.1:3000/ HTTP/1.1
host: 127.0.0.1

%
```

This PR removes the scheme and authority parts of the URI that we send in the HTTP request line.  A URL with only the path and query parts is an origin-form URL.